### PR TITLE
`coact-api` Graceful Shutdown Upon MongoDB Issues

### DIFF
--- a/schema.py
+++ b/schema.py
@@ -3,6 +3,7 @@ from auth import IsAuthenticated, \
         IsAdmin, \
         IsValidEPPN, \
         IsFacilityCzarOrAdmin
+import sys
 
 import os
 import signal
@@ -1595,7 +1596,9 @@ class Subscription:
             while True:
                 req = await all_request_subscriptions[clientName].requests_queue.get()
                 yield req
-        except:
+        except (GeneratorExit, asyncio.CancelledError):
+            raise
+        except Exception:
             pass
         if generatedClientName:
             LOG.warn("Removing anonymous subsctiption %s", clientName)
@@ -1627,6 +1630,12 @@ def start_change_stream_queues(db):
                             LOG.exception("Exception processing change")
                         change = change_stream.try_next()
                     await asyncio.sleep(1)
+                    # try_next() silently retries on connection errors (PyMongo change
+                    # stream auto-resume).  An explicit ping is the only reliable way
+                    # to detect that MongoDB is permanently gone.
+                    await asyncio.get_running_loop().run_in_executor(
+                        None, lambda: db.command("ping")
+                    )
                 except Exception as e:
                     LOG.exception("Lost connection to the change stream; exiting the process")
                     continueProcessing = False
@@ -1634,9 +1643,5 @@ def start_change_stream_queues(db):
                         change_stream.close()
                     except:
                         pass
-                    try:
-                        asyncio.get_running_loop().stop()
-                    except:
-                        pass
-                    os.kill(os.getppid(), signal.SIGKILL)
+                    sys.exit(1)
     asyncio.create_task(__watch_requests__())

--- a/schema.py
+++ b/schema.py
@@ -3,7 +3,6 @@ from auth import IsAuthenticated, \
         IsAdmin, \
         IsValidEPPN, \
         IsFacilityCzarOrAdmin
-import sys
 
 import os
 import signal

--- a/schema.py
+++ b/schema.py
@@ -1643,5 +1643,5 @@ def start_change_stream_queues(db):
                         change_stream.close()
                     except:
                         pass
-                    sys.exit(1)
+                    os.kill(os.getpid(), signal.SIGTERM)
     asyncio.create_task(__watch_requests__())


### PR DESCRIPTION
Three fixes:
- Don't swallow `asyncio.CancelledError`: some processes rely on it for graceful shutdown
- Add `db.command("ping")`: reliable test for db connection, raises if fails
- ~`os.kill` -> `sys.exit(1)`: os.kill can be unreliable in containerized applications~ `sys.exit` does not work in an async environment