### PR TITLE
Raise RuntimeError when repo not found

### DIFF
--- a/schema.py
+++ b/schema.py
@@ -414,6 +414,8 @@ class Query:
             search["users"] = username
         LOG.debug(f"searching for repos using {filter} -> {search}")
         theRepo = info.context.db.collection("repos").find_one(search)
+        if theRepo is None:
+            raise RuntimeError(f"Repo with facility={filter.facility} and name={filter.name} does not exist")
         return info.context.db.cursor_to_objlist([theRepo], Repo, exclude_fields=["access_groups", "features"])[0]
 
     @strawberry.field( permission_classes=[ IsAuthenticated ] )


### PR DESCRIPTION
The `repo` resolver's cursor_to_objlist call raises when a repo does not exist as it attempts to iterate over `None` returned by mongodb's `find_one`.

This change raises a specific `RuntimeError` when a repo is not found for better traceability.

Returning `None` when a repo was not found was also considered, however the blast radiu of such a change is significant and not suited for a hot fix.